### PR TITLE
Add exit statements to shell scripts

### DIFF
--- a/Compilation Files/collective.sh
+++ b/Compilation Files/collective.sh
@@ -3,3 +3,5 @@
 ./compile.sh
 cd SpringBotBall25/"Compilation Files"
 cat run.sh | sshpass -p "botball" ssh -o StrictHostKeyChecking=no kipr@192.168.125.1
+
+exit 0

--- a/Compilation Files/compile.sh
+++ b/Compilation Files/compile.sh
@@ -8,3 +8,5 @@ sudo cp botball_user_program ../execution
 sudo rm -r *
 cd ..
 echo "Compiled sucessfully!"
+
+exit 0

--- a/Compilation Files/debug.sh
+++ b/Compilation Files/debug.sh
@@ -9,3 +9,5 @@ target extended-remote 192.168.125.1:5555
 set remote exec-file /home/kipr/Documents/KISS/test/hmm/bin/botball_user_program
 file /home/aubrey/execution/botball_user_program
 start
+
+exit 0

--- a/Compilation Files/run.sh
+++ b/Compilation Files/run.sh
@@ -1,4 +1,4 @@
 #!/bin/bash
 cd Documents/KISS/test/hmm/bin
 ./botball_user_program
-exit
+exit 0


### PR DESCRIPTION
Ensure all compilation and execution scripts terminate properly by adding exit 0 statements. This improves script reliability and prevents unintended behavior during execution.